### PR TITLE
Fix csp error

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -93,3 +93,11 @@ test("X-Permitted-Cross-Domain-Policies: all", () => {
 		expect(mock.res.headers).toEqual(defaultHeaders);
 	});
 });
+
+test("CSP throws error with a custom option", () => {
+	expect(() => {
+		honoHelmet({
+			contentSecurityPolicy: {},
+		});
+	}).toThrow();
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ class ContentSecurityPolicyHandler {
 	value: string;
 	header: string;
 	constructor(options: ContentSecurityPolicyOptions) {
-		throw Error("Not implemented yet");
+		throw new Error("Not implemented yet");
 		const { useDefaults, directives, reportOnly } = options;
 		this.value = "";
 		this.header =


### PR DESCRIPTION
`ContentSecurityPolicyHandler` takes `ContentSecurityPolicyOptions` that contain CSP directives.

The options are not implemented yet and it will throw an error if you use it.
This PR will fix the error implementation and add a test.