### PR TITLE
Initial implementation of csp directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ app.get("/", (c) => c.text("Hello Hono!"));
 serve(app);
 ```
 
-The default headers are as follows:
+The default header fields are as follows:
 
 ```
 Content-Security-Policy: default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests
@@ -79,7 +79,7 @@ app.use(
 );
 ```
 
-To disable headers:
+To disable header fields:
 
 ```js
 app.use(
@@ -88,3 +88,72 @@ app.use(
   }),
 );
 ```
+
+## Reference
+
+<details>
+<summary><code>honoHelmet(options)</code></summary>
+
+```ts
+// Use the default header fields
+app.use(honoHelmet());
+
+// Disable one or more header fields
+app.use(
+  honoHelmet({
+    contentSecurityPolicy: false,
+  }),
+);
+
+// Use the default header fields but X-Permitted-Cross-Domain-Policies: all
+app.use(
+  honoHelmet({
+    permittedCrossDomainPolicies: {
+      permittedPolicies: "all",
+    },
+  }),
+);
+```
+
+</details>
+
+<details>
+<summary><code>honoHelmet({contentSecurityPolicy: options})</code></summary>
+
+The default directives are as follows:
+
+```
+"default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
+```
+
+```ts
+// Use the defaults but "default-src 'none'
+app.use(
+  honoHelmet({
+    contentSecurityPolicy: {
+      defaultSrc: ["'none'"],
+    },
+  }),
+);
+
+// Use the defaults but disable "default-src"
+app.use(
+  honoHelmet({
+    contentSecurityPolicy: {
+      defaultSrc: false,
+    },
+  }),
+);
+
+// Disable the defaults and "default-src 'none'
+app.use(
+  honoHelmet({
+    contentSecurityPolicy: {
+      useDefaults: false,
+      defaultSrc: ["'none'"],
+    },
+  }),
+);
+```
+
+</details>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,31 +1,47 @@
 import type { Context, MiddlewareHandler, Env } from "hono";
 
+type Sandbox =
+	| "allow-downloads"
+	| "allow-downloads-without-user-activation"
+	| "allow-forms"
+	| "allow-modals"
+	| "allow-orientation-lock"
+	| "allow-pointer-lock"
+	| "allow-popups"
+	| "allow-popups-to-escape-sandbox"
+	| "allow-presentation"
+	| "allow-same-origin"
+	| "allow-scripts"
+	| "allow-storage-access-by-user-activation"
+	| "allow-top-navigation"
+	| "allow-top-navigation-by-user-activation"
+	| "allow-top-navigation-to-custom-protocols";
+
 interface Directives {
-	defaultSrc?: string[];
-	baseUri?: string[];
-	fontSrc?: string[];
-	fontActions?: string[];
-	frameAncestors?: string[];
-	imgSrc?: string[];
-	objectSrc?: string[];
-	scriptSrc?: string[];
-	scriptSrcElem?: string[];
-	scriptSrcAttr?: string[];
-	styleSrc?: string[];
-	styleSrcElem?: string[];
-	styleSrcAttr?: string[];
-	workerSrc?: string[];
-	sandbox?: string[];
-	upgradeInsecureRequests?: string[];
-	childSrc?: string[];
-	connectSrc?: string[];
-	manifestSrc?: string[];
-	mediaSrc?: string[];
-	prefetchSrc?: string[];
-	formAction?: string[];
-	navigateto?: string[];
-	requireTrustedTypesFor?: string[];
-	trustedTypes?: string[];
+	defaultSrc?: string[] | boolean;
+	baseUri?: string[] | boolean;
+	fontSrc?: string[] | boolean;
+	formActions?: string[] | boolean;
+	frameAncestors?: string[] | boolean;
+	imgSrc?: string[] | boolean;
+	objectSrc?: string[] | boolean;
+	scriptSrc?: string[] | boolean;
+	scriptSrcElem?: string[] | false;
+	scriptSrcAttr?: string[] | boolean;
+	styleSrc?: string[] | boolean;
+	styleSrcElem?: string[] | false;
+	styleSrcAttr?: string[] | false;
+	workerSrc?: string[] | false;
+	sandbox?: Sandbox[] | false;
+	upgradeInsecureRequests?: boolean;
+	childSrc?: string[] | false;
+	connectSrc?: string[] | false;
+	manifestSrc?: string[] | false;
+	mediaSrc?: string[] | false;
+	prefetchSrc?: string[] | false;
+	requireTrustedTypesFor?: boolean;
+	trustedTypes?: string[] | false;
+	[key: string]: string[] | boolean | undefined;
 }
 
 interface ContentSecurityPolicyOptions {
@@ -88,20 +104,188 @@ class ContentSecurityPolicyDefaultHandler {
 	}
 }
 
+const defaultCspDirectives: Directives = {
+	defaultSrc: ["'self'"],
+	baseUri: ["'self'"],
+	fontSrc: ["'self' https: data:"],
+	frameAncestors: ["'self'"],
+	imgSrc: ["'self' data:"],
+	objectSrc: ["'none'"],
+	scriptSrc: ["'self'"],
+	scriptSrcAttr: ["'self'"],
+	styleSrc: ["'self' https: 'unsafe-inline'"],
+	upgradeInsecureRequests: true,
+	formAction: ["'self'"],
+};
+
+const createAllDirectives = (directives: Directives): Directives => {
+	const allDirectives = defaultCspDirectives;
+	const mergedDirectives = Object.assign(allDirectives, directives);
+	for (const directive in mergedDirectives) {
+		if (Object.prototype.hasOwnProperty.call(mergedDirectives, directive)) {
+			if (mergedDirectives[directive] === false) {
+				mergedDirectives[directive] = undefined;
+			}
+		}
+	}
+	return mergedDirectives;
+};
+
+const buildDirectivesString = (directives: Directives): string => {
+	const {
+		defaultSrc,
+		baseUri,
+		fontSrc,
+		formActions,
+		frameAncestors,
+		imgSrc,
+		objectSrc,
+		scriptSrc,
+		scriptSrcElem,
+		scriptSrcAttr,
+		styleSrc,
+		styleSrcElem,
+		styleSrcAttr,
+		workerSrc,
+		sandbox,
+		upgradeInsecureRequests,
+		childSrc,
+		connectSrc,
+		manifestSrc,
+		mediaSrc,
+		prefetchSrc,
+		requireTrustedTypesFor,
+		trustedTypes,
+	} = directives;
+	const arr = [];
+	if (defaultSrc === undefined || defaultSrc === true) {
+		arr.push("default-src 'self'");
+	} else if (defaultSrc !== false) {
+		arr.push(`default-src ${defaultSrc.join(" ")}`);
+	}
+	if (baseUri === undefined || baseUri === true) {
+		arr.push("base-uri 'self'");
+	} else if (baseUri !== false) {
+		arr.push(`base-uri ${baseUri.join(" ")}`);
+	}
+	if (fontSrc === undefined || fontSrc === true) {
+		arr.push("font-src 'self' https: data:");
+	} else if (fontSrc !== false) {
+		arr.push(`font-src ${fontSrc.join(" ")}`);
+	}
+	if (formActions === undefined || formActions === true) {
+		arr.push("form-actions 'self'");
+	} else if (formActions !== false) {
+		arr.push(`form-actions ${formActions.join(" ")}`);
+	}
+	if (frameAncestors === undefined || frameAncestors === true) {
+		arr.push("frame-ancestors 'self'");
+	} else if (frameAncestors !== false) {
+		arr.push(`frame-ancestors ${frameAncestors.join(" ")}`);
+	}
+	if (imgSrc === undefined || imgSrc === true) {
+		arr.push("img-src 'self'");
+	} else if (imgSrc !== false) {
+		arr.push(`img-src ${imgSrc.join(" ")}`);
+	}
+	if (objectSrc === undefined || objectSrc === true) {
+		arr.push("object-src 'none'");
+	} else if (objectSrc !== false) {
+		arr.push(`object-src ${objectSrc.join(" ")}`);
+	}
+	if (scriptSrc === undefined || scriptSrc === true) {
+		arr.push("script-src 'self'");
+	} else if (scriptSrc !== false) {
+		arr.push(`script-src ${scriptSrc.join(" ")}`);
+	}
+	if (scriptSrcElem !== undefined && scriptSrcElem !== false) {
+		arr.push(`script-src-elem ${scriptSrcElem.join(" ")}`);
+	}
+	if (scriptSrcAttr === undefined || scriptSrcAttr === true) {
+		arr.push("script-src-attr 'self'");
+	} else if (scriptSrcAttr !== false) {
+		arr.push(`script-src-attr ${scriptSrcAttr.join(" ")}`);
+	}
+	if (styleSrc === undefined || styleSrc === true) {
+		arr.push("style-src 'self' https: 'unsafe-inline'");
+	} else if (styleSrc !== false) {
+		arr.push(`style-src ${styleSrc.join(" ")}`);
+	}
+	if (styleSrcElem !== undefined && styleSrcElem !== false) {
+		arr.push(`style-src-elem ${styleSrcElem.join(" ")}`);
+	}
+	if (styleSrcAttr !== undefined && styleSrcAttr !== false) {
+		arr.push(`style-src-attr ${styleSrcAttr.join(" ")}`);
+	}
+	if (workerSrc !== undefined && workerSrc !== false) {
+		arr.push(`worker-src ${workerSrc.join(" ")}`);
+	}
+	if (sandbox !== undefined && sandbox !== false) {
+		arr.push(`sandbox ${sandbox.join(" ")}`);
+	}
+	if (upgradeInsecureRequests === undefined || upgradeInsecureRequests) {
+		arr.push("upgrade-insecure-requests");
+	}
+	if (childSrc !== undefined && childSrc !== false) {
+		arr.push(`child-src ${childSrc.join(" ")}`);
+	}
+	if (connectSrc !== undefined && connectSrc !== false) {
+		arr.push(`child-src ${connectSrc.join(" ")}`);
+	}
+	if (manifestSrc !== undefined && manifestSrc !== false) {
+		arr.push(`manifest-src ${manifestSrc.join(" ")}`);
+	}
+	if (mediaSrc !== undefined && mediaSrc !== false) {
+		arr.push(`media-src ${mediaSrc.join(" ")}`);
+	}
+	if (prefetchSrc !== undefined && prefetchSrc !== false) {
+		arr.push(`prefetch-src ${prefetchSrc.join(" ")}`);
+	}
+	if (trustedTypes !== undefined && trustedTypes !== false) {
+		if (trustedTypes.length === 0) {
+			arr.push("trusted-types");
+		} else {
+			arr.push(`trusted-types ${trustedTypes.join(" ")}`);
+		}
+	}
+	if (requireTrustedTypesFor) {
+		arr.push("require-trusted-types-for 'script'");
+	}
+	return arr.join(";");
+};
+
 class ContentSecurityPolicyHandler {
-	value: string;
-	header: string;
+	value: string = "";
+	header: string = "";
+	set: (value: Context) => void;
 	constructor(options: ContentSecurityPolicyOptions) {
-		throw new Error("Not implemented yet");
 		const { useDefaults, directives, reportOnly } = options;
-		this.value = "";
+		if (directives === undefined || Object.keys(directives).length === 0) {
+			if (useDefaults === undefined || useDefaults) {
+				this.value = buildDirectivesString(defaultCspDirectives);
+				this.set = (c: Context) => {
+					c.res.headers.set(this.header, this.value);
+				};
+				return;
+			}
+			this.set = (_: Context) => {};
+			return;
+		}
+		if (useDefaults === false) {
+			this.value = buildDirectivesString(directives);
+		} else {
+			this.value = buildDirectivesString(createAllDirectives(directives));
+		}
+		this.set = (c: Context) => {
+			c.res.headers.set(this.header, this.value);
+		};
 		this.header =
 			reportOnly === undefined || reportOnly === false
 				? "Content-Security-Policy"
 				: "Content-Security-Policy-Report-Only";
 	}
 	apply(c: Context): void {
-		c.res.headers.set(this.header, this.value);
+		this.set(c);
 	}
 }
 


### PR DESCRIPTION
This PR enables us to set custom csp directives.

The `report-to` directive is not implemented yet.
The directive needs the `Report-To` field, so some API design decisions are needed.

More tests about this feature are needed to publish this package.